### PR TITLE
override backlight adjustment if laptop-lid is closed

### DIFF
--- a/src/backlightindicator.py
+++ b/src/backlightindicator.py
@@ -41,6 +41,7 @@ from gi.repository import Gio
 import time
 import os
 import webbrowser
+import subprocess
 import dbus
 from configurator import Configuration
 from preferences_dialog import PreferencesDialog
@@ -412,11 +413,23 @@ backlight manually'))
 
     def do_the_work(self):
         print(1)
-        t = threading.Thread(target=self.get_backlight_from_webcam)
-        t.setDaemon(True)
-        t.start()
+        if self.is_lid_open():   #only update the brigtness-setting if lid is open (no nothing if lid is closed)
+            t = threading.Thread(target=self.get_backlight_from_webcam)
+            t.setDaemon(True)
+            t.start()
 
         return True
+
+    def is_lid_open(self):
+        if os.path.isfile("/proc/acpi/button/lid/LID0/state"):
+            #check LID0 for status
+            lid_state = subprocess.getoutput(" grep -Po '(?<=^state:).*\w*$' /proc/acpi/button/lid/LID0/state | tr -d '[:space:]'")
+            if lid_state == "closed":
+                return False
+            else:
+                return True
+        else:
+            return True  #ignore check if file does not exist
 
     def get_about_dialog(self):
         """Create and populate the about dialog."""


### PR DESCRIPTION
Hi Lorenzo, 

first of all, thank you for this cool python script which is really helpfull for me.

Here I have changed the code for reported behaviour on launchpad (<a href="https://bugs.launchpad.net/backlight-indicator/+bug/1668091">bug/1668091</a>). 

backlight-indicator is capturing backlight (taking and evaluating a picture from the laptop-cam) also during times when the lid is closed but the computer is not suspended (because AC-Power is connected...)

Whenever I open the lid from the non-suspended laptop I am facing the minimum set backlight then, because to captured pictures is more or less black.

Optimum behaviour would be, if the laptop-lid switch would getting checked befor the cpaturing runs.

With this change, it checks the laptop-lid state in "/proc/acpi/button/lid/LID0/state". If this file does not exist, this change just do nothing.

Tested as working on my Tuxedo-Book with Ubuntu 16.04 on it. 

Regards,
Matthias from Germany